### PR TITLE
fix added client to sitemap parser

### DIFF
--- a/.changeset/sour-maps-ask.md
+++ b/.changeset/sour-maps-ask.md
@@ -1,0 +1,5 @@
+---
+"serpeo": patch
+---
+
+Added User Agent to Sitemap Parser client

--- a/apps/serpeo/src/generated/bindings.ts
+++ b/apps/serpeo/src/generated/bindings.ts
@@ -88,8 +88,8 @@ siteRunIdSet: "site-run-id-set"
 
 /** user-defined constants **/
 
-export const STORE_FILE = "store.json" as const;
 export const CRAWL_SETTINGS_KEY = "crawl_settings" as const;
+export const STORE_FILE = "store.json" as const;
 
 /** user-defined types **/
 

--- a/crates/seo-plugins/src/utils/sitemap_parser.rs
+++ b/crates/seo-plugins/src/utils/sitemap_parser.rs
@@ -17,6 +17,8 @@ pub enum SitemapParserError {
     SitemapError(String),
     #[error("Page error: {0}")]
     PageError(#[from] PageError),
+    #[error("Client error: {0}")]
+    ClientError(String),
 }
 
 pub struct SitemapParser {
@@ -34,7 +36,7 @@ impl SitemapParser {
         let client = Client::builder()
             .user_agent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3")
             .build()
-            .map_err(|e| SitemapParserError::UrlParseError(e.to_string()))?;
+            .map_err(|e| SitemapParserError::ClientError(e.to_string()))?;
         Ok(Self {
             _url: url,
             base_url,

--- a/crates/seo-plugins/src/utils/sitemap_parser.rs
+++ b/crates/seo-plugins/src/utils/sitemap_parser.rs
@@ -31,10 +31,14 @@ impl SitemapParser {
             .to_url()
             .map_err(|e| SitemapParserError::UrlParseError(e.to_string()))?;
         let base_url = url.clone();
+        let client = Client::builder()
+            .user_agent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3")
+            .build()
+            .map_err(|e| SitemapParserError::UrlParseError(e.to_string()))?;
         Ok(Self {
             _url: url,
             base_url,
-            client: Client::new(),
+            client,
         })
     }
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix custom user agent in `SitemapParser` HTTP client

- Reorder constant declarations in TypeScript bindings file


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sitemap_parser.rs</strong><dd><code>Use custom user agent in SitemapParser HTTP client</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/seo-plugins/src/utils/sitemap_parser.rs

<li>Set a custom user agent for the HTTP client in <code>SitemapParser</code><br> <li> Handle possible client build errors with proper error mapping<br> <li> Replace default client with the custom-configured one


</details>


  </td>
  <td><a href="https://github.com/alexwine36/serpeo/pull/43/files#diff-b8759f3a8b07dfe9a6ff26d110e13928adbc0a55155d1d4bbd457dfa9e85db1a">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bindings.ts</strong><dd><code>Reorder TypeScript constant declarations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/serpeo/src/generated/bindings.ts

<li>Reorder export of <code>STORE_FILE</code> and <code>CRAWL_SETTINGS_KEY</code> constants<br> <li> No functional changes, only declaration order adjustment


</details>


  </td>
  <td><a href="https://github.com/alexwine36/serpeo/pull/43/files#diff-f36e2e79b68afbcfac7dbdb4558aeac6cbda0f3d5eb0d83c02023cb6821f57be">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>